### PR TITLE
fix(expense): delete unused sortable

### DIFF
--- a/app/Filament/Resources/Budgeting/ExpenseResource.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource.php
@@ -73,7 +73,6 @@ class ExpenseResource extends Resource
                     ->icon(fn (Expense $record): string => $record->enumerateCategory->resolveIcon()),
                 TextColumn::make('name'),
                 TextColumn::make('allocations.amount')
-                    ->sortable()
                     ->state(function (Expense $record, Pages\ListExpenses $livewire) {
                         return $record
                             ->allocations()
@@ -90,7 +89,6 @@ class ExpenseResource extends Resource
                         TotalNonAllocatedMoney::make(),
                     ]),
                 TextColumn::make('budgets.amount')
-                    ->sortable()
                     ->label('Realization')
                     ->state(function (Expense $record, Pages\ListExpenses $livewire) {
                         return $record
@@ -108,8 +106,7 @@ class ExpenseResource extends Resource
                 ExpenseProgressBar::make('budgets-bar')
                     ->label('Usage Progress'),
                 ExpenseProgressPercentage::make('budgets-percentage')
-                    ->label('% Usage')
-                    ->sortable(),
+                    ->label('% Usage'),
             ])
             ->actions([
                 ViewAction::make(),

--- a/resources/views/filament/tables/columns/filament/expense-progress-bar.blade.php
+++ b/resources/views/filament/tables/columns/filament/expense-progress-bar.blade.php
@@ -8,7 +8,7 @@
     }
 @endphp
 <div class="w-full px-4">
-    <div class="w-full h-4 bg-gray-200 rounded-full dark:bg-gray-700">
+    <div class="w-full h-4 bg-gray-200 rounded-full dark:bg-gray-700 overflow-hidden">
         <div class="h-4 rounded-full {{ $backgroundColor }}" style="width: {{ min($totalProgress, 100) }}%"></div>
     </div>
 </div>


### PR DESCRIPTION
diff after add `overflow-hidden`, green before, blue after
![Screenshot from 2024-10-27 22-04-04](https://github.com/user-attachments/assets/85e8b313-37ea-4aae-b407-8c0d3730da01)
