### PR TITLE
feat(filament): expense table to be has unrealized amount column

### DIFF
--- a/app/Filament/Resources/Budgeting/ExpenseResource.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource.php
@@ -105,6 +105,7 @@ class ExpenseResource extends Resource
                         TotalBudget::make(),
                     ]),
                 TextColumn::make('unrealized_amount')
+                    ->label('Unrealized Amount')
                     ->state(fn (TextColumn $component) => $component->getTable()->getColumn('allocations.amount')->getState() - $component->getTable()->getColumn('budgets.amount')->getState())
                     ->money(),
                 ExpenseProgressBar::make('budgets-bar')

--- a/app/Filament/Resources/Budgeting/ExpenseResource.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource.php
@@ -83,7 +83,7 @@ class ExpenseResource extends Resource
                             )
                             ->sum('amount');
                     })
-                    ->money('idr', locale: 'id')
+                    ->money()
                     ->summarize([
                         TotalBudget::make(),
                         TotalAllocationMoney::make(),
@@ -100,10 +100,13 @@ class ExpenseResource extends Resource
                             )
                             ->sum('amount');
                     })
-                    ->money('idr', locale: 'id')
+                    ->money()
                     ->summarize([
                         TotalBudget::make(),
                     ]),
+                TextColumn::make('unrealized_amount')
+                    ->state(fn (TextColumn $component) => $component->getTable()->getColumn('allocations.amount')->getState() - $component->getTable()->getColumn('budgets.amount')->getState())
+                    ->money(),
                 ExpenseProgressBar::make('budgets-bar')
                     ->label('Usage Progress'),
                 ExpenseProgressPercentage::make('budgets-percentage')


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cd6cefce-6ca9-4f21-9099-5523096ee7e1)

In short, the "Unrealized Amount" column adds an extra layer of visibility and accountability to budget management, making it easier to analyze and optimize financial performance.

So the users able to now about the amount they do not realized yet and they can make decision in aims not guessing how much they need to add new realization without put in excessive amount