### PR TITLE
fix(expense): quick expense cannot create another

### DIFF
--- a/app/Filament/Resources/Budgeting/ExpenseResource/Actions/QuickExpenseAction.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource/Actions/QuickExpenseAction.php
@@ -7,6 +7,7 @@ use App\Models\Expense;
 use Carbon\Carbon;
 use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
 use Filament\Tables\Actions\CreateAction;
 
 class QuickExpenseAction extends CreateAction
@@ -28,11 +29,22 @@ class QuickExpenseAction extends CreateAction
                     ->label('Realized at')
                     ->default(Carbon::now()),
             ])
-            ->modalHeading(fn (Expense $record): string => 'Create expense: '.$record->name)
-            ->action(function (array $data, Expense $record): void {
+            ->modalHeading(fn (?Expense $record): string => 'Create expense: '.$record?->name)
+            ->action(function (array $data, Expense $record, QuickExpenseAction $action, Form $form, array $arguments): void {
                 $data['expense_id'] = $record->id;
 
                 $record->budgets()->create($data);
+
+                if ($arguments['another'] ?? false) {
+                    $this->callAfter();
+                    $this->sendSuccessNotification();
+
+                    $form->fill();
+
+                    $this->halt();
+
+                    return;
+                }
 
                 $this->success();
             });


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/50f932de-2086-4603-8946-a13a0b5beadb)

In the previously we cannot create another data, when we tried to hit the action it will create the data and closing the action instead of holding the action to still opened