### PR TITLE
feat(expense): add query params to set default state of filter

### DIFF
--- a/app/Filament/Forms/MonthSelect.php
+++ b/app/Filament/Forms/MonthSelect.php
@@ -4,6 +4,8 @@ namespace App\Filament\Forms;
 
 use App\Enums\Month;
 use Filament\Forms\Components\Select;
+use Filament\Resources\Pages\Page;
+use Filament\Resources\RelationManagers\RelationManager;
 use Illuminate\Support\Carbon;
 
 class MonthSelect extends Select
@@ -28,6 +30,6 @@ class MonthSelect extends Select
             'in:'.implode(',', array_keys($component->getOptions())),
         ]);
 
-        $this->default($formatMonth(Carbon::now()->month));
+        $this->default(fn (RelationManager|Page $livewire) => $livewire->month ?? $formatMonth(Carbon::now()->month));
     }
 }

--- a/app/Filament/Forms/YearSelect.php
+++ b/app/Filament/Forms/YearSelect.php
@@ -4,6 +4,8 @@ namespace App\Filament\Forms;
 
 use Carbon\Carbon;
 use Filament\Forms\Components\Select;
+use Filament\Resources\Pages\Page;
+use Filament\Resources\RelationManagers\RelationManager;
 
 class YearSelect extends Select
 {
@@ -25,6 +27,6 @@ class YearSelect extends Select
             'in:'.implode(',', array_keys($component->getOptions())),
         ]);
 
-        $this->default(Carbon::now()->year);
+        $this->default(fn (RelationManager|Page $livewire) => $livewire->year ?? Carbon::now()->year);
     }
 }

--- a/app/Filament/Resources/Budgeting/ExpenseResource.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource.php
@@ -114,7 +114,15 @@ class ExpenseResource extends Resource
                     ->label('% Usage'),
             ])
             ->actions([
-                ViewAction::make(),
+                ViewAction::make()
+                    ->url(fn (Expense $record, Pages\ListExpenses $livewire) => ExpenseResource::getUrl(
+                        'view',
+                        [
+                            'record' => $record,
+                            'month' => $livewire->data['month'],
+                            'year' => $livewire->data['year'],
+                        ]
+                    )),
                 QuickExpenseAction::make(),
             ])
             ->groups([

--- a/app/Filament/Resources/Budgeting/ExpenseResource/RelationManagers/BudgetsRelationManager.php
+++ b/app/Filament/Resources/Budgeting/ExpenseResource/RelationManagers/BudgetsRelationManager.php
@@ -14,6 +14,7 @@ use Filament\Support\Enums\Alignment;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Support\HtmlString;
+use Livewire\Attributes\Url;
 
 class BudgetsRelationManager extends RelationManager
 {
@@ -22,6 +23,12 @@ class BudgetsRelationManager extends RelationManager
     protected static ?string $title = 'Realization';
 
     protected static ?string $icon = 'heroicon-o-light-bulb';
+
+    #[Url]
+    public ?string $year = null;
+
+    #[Url]
+    public ?string $month = null;
 
     public function form(Form $form): Form
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable implements FilamentUser, MustVerifyEmail, Onb
 
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory;
+
     use HasRoles;
     use Notifiable;
 


### PR DESCRIPTION
This PR inject query params to view page from list expense filter to increase UX, so the client no need to adjust filter if they not select current period in the list